### PR TITLE
include unistd.h

### DIFF
--- a/libscws/xdict.c
+++ b/libscws/xdict.c
@@ -20,6 +20,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <unistd.h>
 #ifndef WIN32
 #    include <sys/param.h>
 #endif


### PR DESCRIPTION
在编译为iOS的动态链接库时，需要包含头文件 unistd.h 以便使用unlink函数，否则编译器会报错。