### PR TITLE
fix `Makefile.am:24: error: '#' comment at start of rule is unportable`

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -21,11 +21,9 @@ dist-hook:
 #	-rm -f $(distdir)/libscws/version.h
 
 sync-web:
-	#unison ./web ssh://xunsearch/web/scws $(UNISON_OPT)
 	rsync -avzp --delete ./web/* d10:/data/dockers/php-runner/www/xunsearch/web/scws
 
 dist-web: dist-bzip2
 	mv -f $(distdir).tar.bz2 web/down
 	cd etc && tar czf ../web/down/rules.tgz *.ini
 	make sync-web
-


### PR DESCRIPTION
This PR addresses fix for `error: Makefile.am:24: error: '#' comment at start of rule is unportable` on newer `make` version.

Detailed log see: https://github.com/mnixry/postgres-zhparser/actions/runs/14425399364/job/40453500534